### PR TITLE
PyPy friendly CFFI interface with native parser.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
+import sys
 from distutils.core import setup
 from setuptools.extension import Extension
 from setuptools import find_packages
 
+parser_sources = ['ext/http_parser.c']
+
+if '__pypy__' not in sys.builtin_module_names:
+    parser_sources.append('ext/_parser.c')
+
 httpparser = Extension('geventhttpclient._parser',
-                    sources = ['ext/_parser.c', 'ext/http_parser.c'],
+                    sources = parser_sources,
                     include_dirs = ['ext'])
 
 setup(name='geventhttpclient',

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,17 @@ from setuptools.extension import Extension
 from setuptools import find_packages
 
 parser_sources = ['ext/http_parser.c']
-
 if '__pypy__' not in sys.builtin_module_names:
+    # Normal CPython module will be built
     parser_sources.append('ext/_parser.c')
+    extension_name = 'geventhttpclient._parser'
+else:
+    # CFFI helper module will be built (doesn't use CPython API)
+    extension_name = 'geventhttpclient._cffi__parser_helper'
 
-httpparser = Extension('geventhttpclient._parser',
-                    sources = parser_sources,
-                    include_dirs = ['ext'])
+httpparser = Extension(extension_name,
+                       sources = parser_sources,
+                       include_dirs = ['ext'])
 
 setup(name='geventhttpclient',
        version = '1.1',

--- a/src/geventhttpclient/parser.py
+++ b/src/geventhttpclient/parser.py
@@ -67,23 +67,16 @@ int http_should_keep_alive(http_parser *parser);
 
 const char *http_errno_description(enum http_errno err);
 """)
-    
-    
-    module_path = os.path.dirname(os.path.realpath(__file__))
-    C = None
-    for (s, m, t) in imp.get_suffixes():
-        if t == imp.C_EXTENSION:
-            try:
-                module_abs_path = os.path.join(module_path, '_parser{}'.format(s))
-                C = ffi.dlopen(module_abs_path)
-                break
-            except OSError:
-                pass
 
-    del module_path, module_abs_path
+    from geventhttpclient import __path__ as mod_path
+    mod_name = '_cffi__parser_helper'
+    (mod_fd, mod_file_name, mod_desc) = imp.find_module(mod_name, mod_path)
+    if mod_desc[2] == imp.C_EXTENSION:
+        C = ffi.dlopen(mod_file_name)
+    else:
+        raise ImportError("Native '{}' component library could not be found. Check your installation.".format(mod_name))
 
-    if not C:
-        raise ImportError("Native '_parser' component library could not be found. Check your installation.")
+    del mod_path, mod_name, mod_fd, mod_file_name, mod_desc
 
     class HTTPParseError(httplib.HTTPException):
         def __init__(self, http_errno):

--- a/src/geventhttpclient/parser.py
+++ b/src/geventhttpclient/parser.py
@@ -1,0 +1,93 @@
+import sys
+
+if '__pypy__' not in sys.builtin_module_names:
+    from geventhttpclient._parser import *
+
+else:
+    # Alternative CFFI interface for use with PyPy
+    from httplib import HTTPException
+    from cffi import FFI
+    ffi = FFI.cdef("""
+
+typedef struct {
+  /** PRIVATE **/
+  unsigned char type : 2;     /* enum http_parser_type */
+  unsigned char flags : 6;    /* F_* values from 'flags' enum; semi-public */
+  unsigned char state;        /* enum state from http_parser.c */
+  unsigned char header_state; /* enum header_state from http_parser.c */
+  unsigned char index;        /* index into current matcher */
+
+  uint32_t nread;          /* # bytes read in various scenarios */
+  uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
+
+  /** READ-ONLY **/
+  unsigned short http_major;
+  unsigned short http_minor;
+  unsigned short status_code; /* responses only */
+  unsigned char method;       /* requests only */
+  unsigned char http_errno : 7;
+
+  /* 1 = Upgrade header was present and the parser has exited because of that.
+   * 0 = No upgrade header present.
+   * Should be checked when http_parser_execute() returns in addition to
+   * error checking.
+   */
+  unsigned char upgrade : 1;
+
+  /** PUBLIC **/
+  void *data; /* A pointer to get hook to the "connection" or "socket" object */
+} http_parser;
+
+typedef int (*http_data_cb) (http_parser*, const char *at, size_t length);
+typedef int (*http_cb) (http_parser*);
+
+typedef struct {
+  http_cb      on_message_begin;
+  http_data_cb on_url;
+  http_data_cb on_header_field;
+  http_data_cb on_header_value;
+  http_cb      on_headers_complete;
+  http_data_cb on_body;
+  http_cb      on_message_complete;
+} http_parser_settings;
+
+size_t http_parser_execute(http_parser *parser,
+                           const http_parser_settings *settings,
+                           const char *data,
+                           size_t len);
+""")
+    C = ffi.dlopen('_parser') 
+
+    class HTTPParseError(HTTPException):
+        pass
+    
+    class HTTPResponseParser(object):
+        def __init__(self):
+            self.http_parser = ffi.new("http_parser *")
+            self.http_parser_settings = ffi.new("http_parser_settings *")
+
+        def feed(self, data):
+            buf = ffi.new("char[]", data)
+            self._exception = None
+            ret = C.http_parser_execute(self.http_parser, self.http_parser_settings,
+                                        buf, len(data));
+            if self._exception:
+                raise self._exception
+
+            return ret
+
+        def get_code(self):
+            pass
+
+        def get_http_version(self):
+            pass
+
+        def get_remaining_content_length(self):
+            pass
+
+        def parser_failed(self):
+            pass
+
+        def should_keep_alive(self):
+            pass
+

--- a/src/geventhttpclient/parser.py
+++ b/src/geventhttpclient/parser.py
@@ -70,6 +70,7 @@ const char *http_errno_description(enum http_errno err);
     
     
     module_path = os.path.dirname(os.path.realpath(__file__))
+    C = None
     for (s, m, t) in imp.get_suffixes():
         if t == imp.C_EXTENSION:
             try:
@@ -80,6 +81,9 @@ const char *http_errno_description(enum http_errno err);
                 pass
 
     del module_path, module_abs_path
+
+    if not C:
+        raise ImportError("Native '_parser' component library could not be found. Check your installation.")
 
     class HTTPParseError(httplib.HTTPException):
         def __init__(self, http_errno):

--- a/src/geventhttpclient/response.py
+++ b/src/geventhttpclient/response.py
@@ -1,5 +1,5 @@
 import errno
-from geventhttpclient._parser import HTTPResponseParser, HTTPParseError #@UnresolvedImport
+from geventhttpclient.parser import HTTPResponseParser, HTTPParseError #@UnresolvedImport
 from geventhttpclient.header import Headers
 import gevent.socket
 

--- a/src/geventhttpclient/tests/test_keep_alive.py
+++ b/src/geventhttpclient/tests/test_keep_alive.py
@@ -1,5 +1,5 @@
 from geventhttpclient.response import HTTPResponse
-from geventhttpclient._parser import HTTPParseError
+from geventhttpclient.parser import HTTPParseError
 import pytest
 
 

--- a/src/geventhttpclient/tests/test_parser.py
+++ b/src/geventhttpclient/tests/test_parser.py
@@ -1,5 +1,5 @@
 from geventhttpclient.response import HTTPResponse
-from geventhttpclient._parser import HTTPParseError
+from geventhttpclient.parser import HTTPParseError
 from cStringIO import StringIO
 import pytest
 


### PR DESCRIPTION
In an attempt to better support PyPy on Gevent and its ecosystem, this is a port of _parser.c to CFFI interface, that is the preferred way to call C from PyPy. When installing, the '_parser.c' file will not be built if PyPy is detected, only the 'http_parser.c' from Nginx, that is loaded from the 'parser.py' module. If PyPy is not detected, original CPython extension will be used normally, because '_parser.c' will be built and 'parser.py' will simply import and expose the native module classes.

I wish I knew how to run all those tests without manually loading each test module and running each test function, but for all the tests I cared to run, it passed (when forcing CFFI usage on CPython, on PyPy things are more complicated...).

Gevent support on PyPy is currently alpha, at best, but I hope you accept this patch as a step in the continuous effort to have it fully supported.
