### PR TITLE
Fix insecure flag does't work without ca_certs.

### DIFF
--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -204,8 +204,13 @@ else:
                 family, socktype, protocol)
 
             if self.ssl_context_factory is None:
-                ssl_options = self.default_options.copy()
-                ssl_options.update(self.ssl_options)
+                ssl_options = {}
+                if not self.insecure:
+                    ssl_options = self.default_options.copy()
+                    ssl_options.update(self.ssl_options)
                 return gevent.ssl.wrap_socket(sock, **ssl_options)
             else:
+                if self.insecure:
+                    self.ssl_options = {}
+
                 return self.ssl_context_factory().wrap_socket(sock, **self.ssl_options)

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -73,6 +73,14 @@ def test_simple_ssl():
         assert response.status_code == 200
         response.read()
 
+def test_simple_ssl_insecure():
+    with server(simple_ssl_response) as listener:
+        http = HTTPClient(*listener, insecure=True, ssl=True)
+        response = http.get('/')
+        assert response.status_code == 200
+        response.read()
+
+
 def timeout_on_connect(sock, addr):
     sock.recv(1024)
     sock.sendall(b'HTTP/1.1 200 Ok\r\nContent-Length: 0\r\n\r\n')


### PR DESCRIPTION
When enable `insecure` in ssl_options, it should keep ssl_options is
empty to ssl.wrap_socket.

The default ssl_options is enable 'ca_certs', 'ssl_version' and
'cert_reqs' even if `insecure` is enabled.
