### PR TITLE
Let the client detect the content-length

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -163,6 +163,9 @@ class HTTPClient(object):
         return request
 
     def request(self, method, request_uri, body=b"", headers={}):
+        if type(body) == six.text_type:
+            body = body.encode('utf-8')
+
         request = self._build_request(
             method.upper(), request_uri, body=body, headers=headers)
 
@@ -173,11 +176,10 @@ class HTTPClient(object):
             try:
                 sock.sendall(request.encode())
                 if body:
-                    if type(body) == six.text_type:
-                        sock.sendall(body.encode('iso-8859-1'))
-                    elif type(body) == six.binary_type:
+                    if type(body) == six.binary_type:
                         sock.sendall(body)
                     else:
+                        # TODO: Support non file-like iterables, e.g. `(u"string1", u"string2")`.
                         if six.PY3:
                             sock.sendfile(body)
                         else:

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -163,7 +163,7 @@ class HTTPClient(object):
         return request
 
     def request(self, method, request_uri, body=b"", headers={}):
-        if type(body) == six.text_type:
+        if isinstance(body, six.text_type):
             body = body.encode('utf-8')
 
         request = self._build_request(
@@ -176,7 +176,7 @@ class HTTPClient(object):
             try:
                 sock.sendall(request.encode())
                 if body:
-                    if type(body) == six.binary_type:
+                    if isinstance(body, six.binary_type):
                         sock.sendall(body)
                     else:
                         # TODO: Support non file-like iterables, e.g. `(u"string1", u"string2")`.

--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 import pytest
 import json
@@ -10,7 +11,6 @@ import gevent.pool
 import gevent.server
 import gevent.pywsgi
 from six.moves import xrange
-
 
 listener = ('127.0.0.1', 54323)
 
@@ -85,6 +85,10 @@ def test_response_context_manager():
         r = response
     assert r._sock is None # released
 
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true",
+    reason="We have issues on travis with the SSL tests"
+)
 def test_client_ssl():
     client = HTTPClient('www.google.fr', ssl=True)
     assert client.port == 443
@@ -93,6 +97,11 @@ def test_client_ssl():
     body = response.read()
     assert len(body)
 
+@pytest.mark.skipif(
+    sys.version_info < (2, 7)
+    and os.environ.get("TRAVIS") == "true",
+    reason="We have issues on travis with the SSL tests"
+)
 def test_ssl_fail_invalid_certificate():
     certs = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "oncert.pem")

--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -269,3 +269,10 @@ def test_string_post():
     with wsgiserver(check_upload("12345", 5)):
         client = HTTPClient(*listener)
         client.post('/', "12345")
+
+def test_unicode_post():
+    byte_string = b'\xc8\xb9\xc8\xbc\xc9\x85'
+    unicode_string = byte_string.decode('utf-8')
+    with wsgiserver(check_upload(byte_string, len(byte_string))):
+        client = HTTPClient(*listener)
+        client.post('/', unicode_string)

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -1,15 +1,22 @@
 import six
+import sys
 from contextlib import contextmanager
 import pytest
 import gevent.server
 import gevent.socket
 import gevent.ssl
-import os.path
+import os
 from geventhttpclient import HTTPClient
 try:
     from ssl import CertificateError
 except ImportError:
     from backports.ssl_match_hostname import CertificateError
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7)
+    and os.environ.get("TRAVIS") == "true",
+    reason="We have issues on travis with the SSL tests"
+)
 
 BASEDIR = os.path.dirname(__file__)
 KEY = os.path.join(BASEDIR, 'server.key')

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -61,6 +61,15 @@ def test_string_post():
         useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload="12345")
 
 
+def test_unicode_post():
+    byte_string = b'\xc8\xb9\xc8\xbc\xc9\x85'
+    unicode_string = byte_string.decode('utf-8')
+    headers = {'CONTENT_LENGTH': str(len(byte_string)), 'CONTENT_TYPE': 'application/octet-stream'}
+    with wsgiserver(check_upload(byte_string, headers)):
+        useragent = UserAgent()
+        useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload=unicode_string)
+
+
 def test_bytes_post():
     headers = {'CONTENT_LENGTH': '5', 'CONTENT_TYPE': 'application/octet-stream'}
     with wsgiserver(check_upload(b"12345", headers)):

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -40,6 +40,12 @@ def test_string_post():
         useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload="12345")
 
 
+def test_bytes_post():
+    with wsgiserver(check_upload(b"12345", 5)):
+        useragent = UserAgent()
+        useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload=b"12345")
+
+
 def test_redirect():
     with wsgiserver(check_redirect()):
         useragent = UserAgent()

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -54,17 +54,10 @@ def test_file_post():
         os.remove(name)
 
 
-def test_string_post():
-    headers = {'CONTENT_LENGTH': '5', 'CONTENT_TYPE': 'application/octet-stream'}
-    with wsgiserver(check_upload(b"12345", headers)):
-        useragent = UserAgent()
-        useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload="12345")
-
-
 def test_unicode_post():
     byte_string = b'\xc8\xb9\xc8\xbc\xc9\x85'
     unicode_string = byte_string.decode('utf-8')
-    headers = {'CONTENT_LENGTH': str(len(byte_string)), 'CONTENT_TYPE': 'application/octet-stream'}
+    headers = {'CONTENT_LENGTH': str(len(byte_string)), 'CONTENT_TYPE': 'text/plain; charset=utf-8'}
     with wsgiserver(check_upload(byte_string, headers)):
         useragent = UserAgent()
         useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload=unicode_string)

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -1,5 +1,9 @@
-from contextlib import contextmanager
 import gevent.pywsgi
+import os
+import six
+import tempfile
+
+from contextlib import contextmanager
 from geventhttpclient.useragent import UserAgent
 
 
@@ -13,9 +17,10 @@ def wsgiserver(handler):
         server.stop()
 
 
-def check_upload(body, body_length):
+def check_upload(body, headers=None):
     def wsgi_handler(env, start_response):
-        assert int(env.get('CONTENT_LENGTH')) == body_length
+        if headers:
+            assert six.viewitems(env) >= six.viewitems(headers)
         assert body == env['wsgi.input'].read()
         start_response('200 OK', [])
         return []
@@ -34,14 +39,31 @@ def check_redirect():
     return wsgi_handler
 
 
+def test_file_post():
+    body = tempfile.NamedTemporaryFile("a+b", delete=False)
+    name = body.name
+    try:
+        body.write(b"123456789")
+        body.close()
+        headers = {'CONTENT_LENGTH': '9', 'CONTENT_TYPE': 'application/octet-stream'}
+        with wsgiserver(check_upload(b"123456789", headers)):
+            useragent = UserAgent()
+            with open(name, 'rb') as body:
+                useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload=body)
+    finally:
+        os.remove(name)
+
+
 def test_string_post():
-    with wsgiserver(check_upload(b"12345", 5)):
+    headers = {'CONTENT_LENGTH': '5', 'CONTENT_TYPE': 'application/octet-stream'}
+    with wsgiserver(check_upload(b"12345", headers)):
         useragent = UserAgent()
         useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload="12345")
 
 
 def test_bytes_post():
-    with wsgiserver(check_upload(b"12345", 5)):
+    headers = {'CONTENT_LENGTH': '5', 'CONTENT_TYPE': 'application/octet-stream'}
+    with wsgiserver(check_upload(b"12345", headers)):
         useragent = UserAgent()
         useragent.urlopen('http://127.0.0.1:54323/', method='POST', payload=b"12345")
 

--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -6,7 +6,7 @@ import zlib
 import os
 from six.moves import xrange, cStringIO
 from six.moves.urllib.parse import urlencode
-from six import print_, reraise, string_types
+from six import print_, reraise, string_types, text_type
 
 import gevent
 try:
@@ -274,6 +274,8 @@ class UserAgent(object):
             if not content_type and isinstance(payload, dict):
                 req_headers['content-type'] = "application/x-www-form-urlencoded; charset=utf-8"
                 payload = urlencode(payload)
+            elif not content_type and isinstance(payload, text_type):
+                req_headers['content-type'] = 'text/plain; charset=utf-8'
             elif not content_type:
                 req_headers['content-type'] = 'application/octet-stream'
             elif content_type.startswith("multipart/form-data"):

--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -274,18 +274,12 @@ class UserAgent(object):
             if not content_type and isinstance(payload, dict):
                 req_headers['content-type'] = "application/x-www-form-urlencoded; charset=utf-8"
                 payload = urlencode(payload)
-                req_headers['content-length'] = len(payload)
             elif not content_type:
                 req_headers['content-type'] = 'application/octet-stream'
-                payload = payload if isinstance(payload, string_types) else str(payload)
-                req_headers['content-length'] = len(payload)
             elif content_type.startswith("multipart/form-data"):
                 # See restkit for some example implementation
                 # TODO: Implement it
                 raise NotImplementedError
-            else:
-                payload = payload if isinstance(payload, string_types) else str(payload)
-                req_headers['content-length'] = len(payload)
         return CompatRequest(url, method=method, headers=req_headers, payload=payload)
 
     def _urlopen(self, request):


### PR DESCRIPTION
Don't duplicate the payload content-length detection on the useragent
layer. Let the client handle that.

The useragent is still responsible for setting the right content-type
and for translating the payload in the basic supported payload types
(bytes, strings and stream variants like files).