### PR TITLE
Exclude compiled files from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include src/geventhttpclient/*.py
 include ext/*.c
 include ext/*.h
 recursive-include src/geventhttpclient/tests *
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
@gwik You left a `./src/geventhttpclient/tests/__pycache__` folder in the PyPI tarball for 1.3.1. I think this is the way to get rid of those.