### PR TITLE
Send http header and body in one packet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
 install:

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -174,11 +174,12 @@ class HTTPClient(object):
         while 1:
             sock = self._connection_pool.get_socket()
             try:
-                sock.sendall(request.encode())
+                _request = request.encode()
                 if body:
                     if isinstance(body, six.binary_type):
-                        sock.sendall(body)
+                        sock.sendall(_request + body)
                     else:
+                        sock.sendall(_request)
                         # TODO: Support non file-like iterables, e.g. `(u"string1", u"string2")`.
                         if six.PY3:
                             sock.sendfile(body)
@@ -188,6 +189,8 @@ class HTTPClient(object):
                                 if not chunk:
                                     break
                                 sock.sendall(chunk)
+                else:
+                    sock.sendall(_request)
             except gevent.socket.error as e:
                 self._connection_pool.release_socket(sock)
                 if (e.errno == errno.ECONNRESET or e.errno == errno.EPIPE) and attempts_left > 0:


### PR DESCRIPTION
geventhttpclient will send http header first, then send body. It will split header and body in two packets.

In my prod env, I tried to replace requests with geventhttpclient on frontend webservers (they will calll backend http servers). System load decreased a lot, but  latency increased. After some debugging, I find the root case is above. One more packet has additional ip+tcp header.

Following is the latency change graph when I merge the header and body in one packet

![screen shot 2017-05-16 at 3 57 39 pm](https://cloud.githubusercontent.com/assets/813489/26095492/6f15f7ce-3a50-11e7-8dec-c90a95310a2a.png)

