### PR TITLE
Use UserAgent.request_type and UserAgent.response_type when constructing request/response

### DIFF
--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -283,13 +283,13 @@ class UserAgent(object):
                 # See restkit for some example implementation
                 # TODO: Implement it
                 raise NotImplementedError
-        return CompatRequest(url, method=method, headers=req_headers, payload=payload)
+        return self.request_type(url, method=method, headers=req_headers, payload=payload)
 
     def _urlopen(self, request):
         client = self.clientpool.get_client(request.url_split)
         resp = client.request(request.method, request.url_split.request_uri,
                               body=request.payload, headers=request.headers)
-        return CompatResponse(resp, request=request, sent_request=resp._sent_request)
+        return self.response_type(resp, request=request, sent_request=resp._sent_request)
 
     def _verify_status(self, status_code, url=None):
         """ Hook for subclassing


### PR DESCRIPTION
I noticed that the UserAgent class attributes response_type and request_type seen here:

https://github.com/gwik/geventhttpclient/blob/328ae0b82a90bf0157c092af89a777c0f85aaa72/src/geventhttpclient/useragent.py#L246-L247

isn't actually used when constructing the request and response. I assume this is unintentional? This PR fixes so that are actually used.