### PR TITLE
Automatically build python wheels and upload to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,41 @@ python:
 install:
   - "pip install ."
 script: py.test src/geventhttpclient/tests
+
+jobs:
+  include:
+    - stage: build
+      sudo: required
+      services:
+        - docker
+      os: linux
+      python: "3.6"
+      install:
+        - pip install cibuildwheel==0.6.0
+      script:
+        - cibuildwheel --output-dir wheelhouse
+        # Upload to PyPI on tags
+        - if [ "${TRAVIS_TAG:-}" != "" ]; then
+            pip install twine;
+            python -m twine upload --skip-existing wheelhouse/*;
+          fi
+    - stage: build
+      sudo: required
+      os: osx
+      osx_image: xcode8.3
+      language: null
+      python: null
+      install:
+        # Python 3 is needed to run cibuildwheel
+        - if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then
+            brew update;
+            brew install python3;
+          fi
+        - pip3 install cibuildwheel==0.6.0
+      script:
+        - cibuildwheel --output-dir wheelhouse
+        # Upload to PyPI on tags
+        - if [ "${TRAVIS_TAG:-}" != "" ]; then
+            pip3 install twine;
+            python3 -m twine upload --skip-existing wheelhouse/*;
+          fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+build_script:
+  - pip install cibuildwheel==0.6.0
+  - cibuildwheel --output-dir wheelhouse
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
+        python -m pip install twine
+        python -m twine upload --skip-existing (resolve-path wheelhouse\*.whl)
+      }
+artifacts:
+  - path: "wheelhouse\\*.whl"
+    name: Wheels


### PR DESCRIPTION
This pull-request fixes so that binary wheels are automatically built on Travis.ci (for Linux & Mac) and Appveyor (for Windows). It also makes it so that the wheels are automatically uploaded to PyPI if a new git tag is pushed.

For the windows wheels to be built, [Appveyor](https://www.appveyor.com/) must be activated for this repository. It's free for open source projects.

For the uploading to PyPI to work, the environment variables `TWINE_USERNAME` and `TWINE_PASSWORD` must be set in the settings on Travis.ci and Appveyor (should be set to a user/pass of an account with upload access to the PyPI package).

This is a pull-request for #93 