### PR TITLE
Include license and basic docu in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,6 @@ include ext/*.h
 recursive-include src/geventhttpclient/tests *
 global-exclude __pycache__
 global-exclude *.py[co]
+include LICENSE-MIT
+include README.mdown
+include CHANGELOG


### PR DESCRIPTION
For obvious reasons at least license should be present in pypi archive.