### PR TITLE
Mark tests that use internet as online

### DIFF
--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -34,6 +34,7 @@ def wsgiserver(handler):
     finally:
         server.stop()
 
+@pytest.mark.online
 def test_client_simple():
     client = HTTPClient('httpbin.org')
     assert client.port == 80
@@ -42,6 +43,7 @@ def test_client_simple():
     body = response.read()
     assert len(body)
 
+@pytest.mark.online
 def test_client_without_leading_slash():
     client = HTTPClient('httpbin.org')
     with client.get("") as response:
@@ -50,9 +52,11 @@ def test_client_without_leading_slash():
         assert(response.status_code in (200, 301, 302))
 
 test_headers = {'User-Agent': 'Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.2.17) Gecko/20110422 Ubuntu/10.04 (lucid) Firefox/3.6.17'}
+@pytest.mark.online
 def test_client_with_default_headers():
     client = HTTPClient.from_url('httpbin.org/', headers=test_headers)
 
+@pytest.mark.online
 def test_request_with_headers():
     client = HTTPClient('httpbin.org')
     response = client.get('/', headers=test_headers)
@@ -61,22 +65,27 @@ def test_request_with_headers():
 client = HTTPClient('www.heise.de')
 raw_req_cmp = client._build_request('GET', '/tp/')
 
+@pytest.mark.online
 def test_build_request_relative_uri():
     raw_req = client._build_request('GET', 'tp/')
     assert raw_req == raw_req_cmp
 
+@pytest.mark.online
 def test_build_request_absolute_uri():
     raw_req = client._build_request('GET', '/tp/')
     assert raw_req == raw_req_cmp
 
+@pytest.mark.online
 def test_build_request_full_url():
     raw_req = client._build_request('GET', 'http://www.heise.de/tp/')
     assert raw_req == raw_req_cmp
 
+@pytest.mark.online
 def test_build_request_invalid_host():
     with pytest.raises(ValueError):
         client._build_request('GET', 'http://www.spiegel.de/')
 
+@pytest.mark.online
 def test_response_context_manager():
     client = HTTPClient.from_url('http://httpbin.org/')
     r = None
@@ -89,6 +98,7 @@ def test_response_context_manager():
     os.environ.get("TRAVIS") == "true",
     reason="We have issues on travis with the SSL tests"
 )
+@pytest.mark.online
 def test_client_ssl():
     client = HTTPClient('github.com', ssl=True)
     assert client.port == 443
@@ -102,6 +112,7 @@ def test_client_ssl():
     and os.environ.get("TRAVIS") == "true",
     reason="We have issues on travis with the SSL tests"
 )
+@pytest.mark.online
 def test_ssl_fail_invalid_certificate():
     certs = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "oncert.pem")
@@ -111,6 +122,7 @@ def test_ssl_fail_invalid_certificate():
         client.get('/')
     assert e_info.value.reason == 'CERTIFICATE_VERIFY_FAILED'
 
+@pytest.mark.online
 def test_multi_queries_greenlet_safe():
     client = HTTPClient('httpbin.org', concurrency=3)
     group = gevent.pool.Group()


### PR DESCRIPTION
This allows quick skipping for enviroments without the connection.

Issue #112