### PR TITLE
Remove Python 3.4 and add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - "pip install -r requirements-dev.txt"
   - "pip install ."

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36}
+envlist = py{27,35,36,37}
 [testenv]
 whitelist_externals =
     rm


### PR DESCRIPTION
This removes Python 3.4 (deprecated) from the test matrix, and adds Python 3.7.