### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/src/geventhttpclient/header.py
+++ b/src/geventhttpclient/header.py
@@ -1,5 +1,9 @@
-from collections import Mapping, MutableMapping
 import six
+
+if six.PY3:
+    from collections.abc import Mapping, MutableMapping
+else:
+    from collections import Mapping, MutableMapping
 
 _dict_setitem = dict.__setitem__
 _dict_getitem = dict.__getitem__


### PR DESCRIPTION
Fixes #122 