### PR TITLE
Register pytest.mark.online to avoid PytestUnknownMarkWarning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+  online: tests which require internet access


### PR DESCRIPTION
Without this, pytest throws a bunch of warnings like this one:
```
src/geventhttpclient/tests/test_client.py:125: PytestUnknownMarkWarning: Unknown pytest.mark.online - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
```