### PR TITLE
Include pytest.ini in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ global-exclude *.py[co]
 include LICENSE-MIT
 include README.mdown
 include CHANGELOG
+include pytest.ini


### PR DESCRIPTION
This is required after the change in #127 to get rid of `PytestUnknownMarkWarning`.