### PR TITLE
Don't auto parse query string. Add params keyword argument.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       #    brew upgrade python;
       #    true;
       #  fi
-      - pip3 install cibuildwheel==1.3.0
+      - pip3 install cibuildwheel>=1.7.1
     script:
       - cibuildwheel --output-dir wheelhouse
       # Upload to PyPI on tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,15 @@ jobs:
       - CIBW_SKIP="cp33 cp34"
   - stage: build
     os: osx
-    osx_image: xcode9.4
+    osx_image: xcode12.2
     language: generic
     install:
       # Python 3 is needed to run cibuildwheel
-      - if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then
-          brew update;
-          brew upgrade python;
-          true;
-        fi
+      #- if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then
+      #    brew update;
+      #    brew upgrade python;
+      #    true;
+      #  fi
       - pip3 install cibuildwheel==1.3.0
     script:
       - cibuildwheel --output-dir wheelhouse

--- a/src/geventhttpclient/tests/test_url.py
+++ b/src/geventhttpclient/tests/test_url.py
@@ -9,8 +9,7 @@ def test_simple_url():
     assert url.path == '/subdir/file.py'
     assert url.host == 'getgauss.com'
     assert url.port == 80
-    assert url['param'] == 'value'
-    assert url['other'] == 'true'
+    assert url.query_string == 'param=value&other=true'
     assert url.fragment == 'frag'
 
 def test_path_only():
@@ -18,14 +17,29 @@ def test_path_only():
     assert url.host == ''
     assert url.port == None
     assert url.path == '/path/to/something'
-    assert url['param'] == 'value'
-    assert url['other'] == 'true'
+    assert url.query_string == 'param=value&other=true'
+
+def test_params():
+    url = URL(url_full, params={"pp":"hello"})
+    assert url.path == '/subdir/file.py'
+    assert url.host == 'getgauss.com'
+    assert url.port == 80
+    assert url.query_string == 'param=value&other=true&pp=hello'
+    assert url.fragment == 'frag'
+
+def test_params_urlencoded():
+    url = URL(url_full, params={"a/b":"c/d"})
+    assert url.path == '/subdir/file.py'
+    assert url.host == 'getgauss.com'
+    assert url.port == 80
+    assert url.query_string == 'param=value&other=true&a%2Fb=c%2Fd'
+    assert url.fragment == 'frag'    
 
 def test_empty():
     url = URL()
     assert url.host == ''
     assert url.port == 80
-    assert url.query == {}
+    assert url.query_string == ''
     assert url.fragment == ''
     assert url.netloc == ''
     assert str(url) == 'http:///'
@@ -46,7 +60,7 @@ def test_redirection_abs_path():
     assert updated.host == url.host
     assert updated.port == url.port
     assert updated.path == '/test.html'
-    assert updated.query == {}
+    assert updated.query_string == ''
     assert updated.fragment == ''
 
 def test_redirection_rel_path():
@@ -57,7 +71,7 @@ def test_redirection_rel_path():
         assert updated.port == url.port
         assert updated.path.startswith('/subdir/')
         assert updated.path.endswith(redir.split('?', 1)[0])
-        assert updated.query == {'key': 'val'}
+        assert updated.query_string == 'key=val'
         assert updated.fragment == ''
 
 def test_redirection_full_path():
@@ -69,16 +83,10 @@ def test_redirection_full_path():
         assert getattr(updated, attr) == getattr(url_full2, attr)
     assert str(url_full2) == url_full2_plain
 
-def test_set_safe_encoding():
-    class SafeModURL(URL):
-        quoting_safe = '*'
-    surl = '/path/to/something?param=value&other=*'
 
-    assert URL(surl).query_string == 'other=%2A&param=value' or  URL(surl).query_string == 'param=value&other=%2A'
-    assert SafeModURL(surl).query_string == 'other=*&param=value' or SafeModURL(surl).query_string == 'param=value&other=*'
-    URL.quoting_safe = '*'
-    assert URL(surl).query_string == 'other=*&param=value' or URL(surl).query_string == 'param=value&other=*'
-    URL.quoting_safe = ''
+def test_params():
+    assert URL("/some/url", params={"a":"b", "c":2}).query_string == "a=b&c=2"
+
 
 def test_equality():
     assert URL('https://example.com/') != URL('http://example.com/')

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -56,6 +56,13 @@ def check_redirect():
             return [b"redirected"]
     return wsgi_handler
 
+def check_querystring():
+    def wsgi_handler(env, start_response):
+        querystring = env["QUERY_STRING"]
+        start_response('200 OK', [("Content-type", "text/plaim")])
+        return [querystring.encode("utf-8")]
+    return wsgi_handler
+
 def set_cookie():
     def wsgi_handler(env, start_response):
         start_response('200 OK', [('Set-Cookie', 'testcookie=testdata')])
@@ -100,6 +107,17 @@ def test_redirect():
         assert resp.status_code == 200
         assert b"redirected" == resp.content
 
+def test_params():
+    with wsgiserver(check_querystring()):
+        resp = UserAgent().urlopen('http://127.0.0.1:54323/?param1=b', params={"param2":"hello"})
+        assert resp.status_code == 200
+        assert resp.content == b"param1=b&param2=hello"
+
+def test_params_quoted():
+    with wsgiserver(check_querystring()):
+        resp = UserAgent().urlopen('http://127.0.0.1:54323/?a/b', params={"path":"/"})
+        assert resp.status_code == 200
+        assert resp.content == b"a/b&path=%2F"
 
 def test_server_error_with_bytes():
     with wsgiserver(internal_server_error()):


### PR DESCRIPTION
Currently it's not possible to make requests to URLs where the query string don't follow the default `param=value` format, even though they are valid URLs. An example of a URL that you can't make a request to with geventhttpclient:

`http://example.com/get-file?path/to/my/file`

This PR fixes this by removing the automatic parsing and urlencode:ing of the query string that is passed in the URL. 

In order to still provide a way for supplying URL parameters that should be urlencoded, this PR also adds a `params` keyword argument to the `URL` class, `CompatRequest` and `UserAgent.urlopen`. This will make the API more similar to python requests (they don't urlencode the query string passed in the URL, but has a `params` keyword argument whose values will be urlencoded).

Additionally, this PR removes the functionality for getting and setting query parameters of URL class instances using `__getitem__` and `__setitem__`. This is because that functionality *requires* parsing of the URL query string.

This should also fix #51.