### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/ext/_parser.c
+++ b/ext/_parser.c
@@ -184,7 +184,7 @@ PyHTTPResponseParser_feed(PyHTTPResponseParser *self, PyObject* args)
         size_t nread;
         PyObject * exception;
 
-        /* in case feed is called again after an error occured */
+        /* in case feed is called again after an error occurred */
         if (self->parser->http_errno != HPE_OK)
             return set_parser_exception(self->parser);
 

--- a/ext/http_parser.c
+++ b/ext/http_parser.c
@@ -1832,7 +1832,7 @@ reexecute:
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
          * will interpret that as saying that this message has no body. This
-         * is needed for the annoying case of recieving a response to a HEAD
+         * is needed for the annoying case of receiving a response to a HEAD
          * request.
          *
          * We'd like to use CALLBACK_NOTIFY_NOADVANCE() here but we cannot, so
@@ -1943,7 +1943,7 @@ reexecute:
             && parser->content_length != ULLONG_MAX);
 
         /* The difference between advancing content_length and p is because
-         * the latter will automaticaly advance on the next loop iteration.
+         * the latter will automatically advance on the next loop iteration.
          * Further, if content_length ends up at 0, we want to see the last
          * byte again for our message complete callback.
          */
@@ -2437,7 +2437,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_dead:
         return 1;
 
-      /* Skip delimeters */
+      /* Skip delimiters */
       case s_req_schema_slash:
       case s_req_schema_slash_slash:
       case s_req_server_start:

--- a/ext/http_parser.h
+++ b/ext/http_parser.h
@@ -77,7 +77,7 @@ typedef struct http_parser_settings http_parser_settings;
  * chunked' headers that indicate the presence of a body.
  *
  * Returning `2` from on_headers_complete will tell parser that it should not
- * expect neither a body nor any futher responses on this connection. This is
+ * expect neither a body nor any further responses on this connection. This is
  * useful for handling responses to a CONNECT request which may not contain
  * `Upgrade` or `Connection: upgrade` headers.
  *

--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -96,7 +96,7 @@ class ConnectionPool(object):
         return sock
 
     def _create_socket(self):
-        """ might be overriden and super for wrapping into a ssl socket
+        """ might be overridden and super for wrapping into a ssl socket
             or set tcp/socket options
         """
         sock_infos = self._resolve()
@@ -208,7 +208,7 @@ else:
         :param port: port
         :param ssl_options: accepts any options supported by `ssl.wrap_socket`
         :param ssl_context_factory: use `ssl.create_default_context` by default
-            if provided. It must be a callbable that returns a SSLContext.
+            if provided. It must be a callable that returns a SSLContext.
         """
 
         default_options = {


### PR DESCRIPTION
There are small typos in:
- ext/_parser.c
- ext/http_parser.c
- ext/http_parser.h
- src/geventhttpclient/connectionpool.py

Fixes:
- Should read `receiving` rather than `recieving`.
- Should read `overridden` rather than `overriden`.
- Should read `occurred` rather than `occured`.
- Should read `further` rather than `futher`.
- Should read `delimiters` rather than `delimeters`.
- Should read `callable` rather than `callbable`.
- Should read `automatically` rather than `automaticaly`.

Closes #143